### PR TITLE
fix: inherit from `Validator` interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@defi-wonderland/prophet-core": "0.0.0-2e39539b",
+    "@defi-wonderland/prophet-core": "0.0.0-0954a47f",
     "@openzeppelin/contracts": "4.9.5",
     "solmate": "https://github.com/transmissions11/solmate.git#bfc9c25865a274a7827fea5abf6e4fb64fc64e6c"
   },

--- a/solidity/contracts/extensions/AccountingExtension.sol
+++ b/solidity/contracts/extensions/AccountingExtension.sol
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import {Validator} from '@defi-wonderland/prophet-core/solidity/contracts/Validator.sol';
 import {IOracle} from '@defi-wonderland/prophet-core/solidity/interfaces/IOracle.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import {EnumerableSet} from '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
-
-import {Validator} from '@defi-wonderland/prophet-core/solidity/contracts/Validator.sol';
 
 import {IAccountingExtension} from '../../interfaces/extensions/IAccountingExtension.sol';
 

--- a/solidity/interfaces/extensions/IAccountingExtension.sol
+++ b/solidity/interfaces/extensions/IAccountingExtension.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import {IValidator} from '@defi-wonderland/prophet-core/solidity/interfaces/IValidator.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 /*
@@ -8,7 +9,7 @@ import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
   * @notice Extension allowing users to deposit and bond funds
   * to be used for payments and disputes.
   */
-interface IAccountingExtension {
+interface IAccountingExtension is IValidator {
   /*///////////////////////////////////////////////////////////////
                               EVENTS
   //////////////////////////////////////////////////////////////*/

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,10 +193,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@defi-wonderland/prophet-core@0.0.0-2e39539b":
-  version "0.0.0-2e39539b"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/prophet-core/-/prophet-core-0.0.0-2e39539b.tgz#dbf01ed05a9af302841123c77e84bc0b3b4a6176"
-  integrity sha512-EdYpDEO1XeO08uQikhOQ6NzG0LWYxANFk272j4vCyLSJ8kRyJNMv69JJCLcq5kV0B9IzXybmqjreemkZ05z3kQ==
+"@defi-wonderland/prophet-core@0.0.0-0954a47f":
+  version "0.0.0-0954a47f"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/prophet-core/-/prophet-core-0.0.0-0954a47f.tgz#83124e103738a1d1d33b555ea774acbb90c0c153"
+  integrity sha512-MFJt7IQAkZys0wsJtFR4kt1x7zB1PMLr+jd40s14tLshlWm/7zrog8pfxUQ4EzYjVGkLKJm8jR8WcrEhCla39Q==
 
 "@defi-wonderland/solidity-utils@0.0.0-3e9c8e8b":
   version "0.0.0-3e9c8e8b"


### PR DESCRIPTION
Same rationale as in https://github.com/defi-wonderland/prophet-core/pull/43.