### PR TITLE
 refactor: use block.timestamp instead of block.number

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@defi-wonderland/prophet-core": "github:defi-wonderland/prophet-core#de18a05",
+    "@defi-wonderland/prophet-core": "0.0.0-4d28a0ec",
     "@openzeppelin/contracts": "4.9.5",
     "solmate": "https://github.com/transmissions11/solmate.git#bfc9c25865a274a7827fea5abf6e4fb64fc64e6c"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@defi-wonderland/prophet-core": "0.0.0-0954a47f",
+    "@defi-wonderland/prophet-core": "github:defi-wonderland/prophet-core#de18a05",
     "@openzeppelin/contracts": "4.9.5",
     "solmate": "https://github.com/transmissions11/solmate.git#bfc9c25865a274a7827fea5abf6e4fb64fc64e6c"
   },

--- a/solidity/contracts/modules/dispute/BondEscalationModule.sol
+++ b/solidity/contracts/modules/dispute/BondEscalationModule.sol
@@ -51,8 +51,7 @@ contract BondEscalationModule is Module, IBondEscalationModule {
       _requestId: _dispute.requestId,
       _responseId: _dispute.responseId,
       _disputeId: _disputeId,
-      _dispute: _dispute,
-      _blockNumber: block.number
+      _dispute: _dispute
     });
 
     // Only the first dispute of a request should go through the bond escalation

--- a/solidity/contracts/modules/dispute/BondEscalationModule.sol
+++ b/solidity/contracts/modules/dispute/BondEscalationModule.sol
@@ -36,7 +36,7 @@ contract BondEscalationModule is Module, IBondEscalationModule {
     RequestParameters memory _params = decodeRequestData(_request.disputeModuleData);
     BondEscalation storage _escalation = _escalations[_dispute.requestId];
 
-    if (block.number > ORACLE.responseCreatedAt(_dispute.responseId) + _params.disputeWindow) {
+    if (block.timestamp > ORACLE.responseCreatedAt(_dispute.responseId) + _params.disputeWindow) {
       revert BondEscalationModule_DisputeWindowOver();
     }
 

--- a/solidity/contracts/modules/dispute/BondedDisputeModule.sol
+++ b/solidity/contracts/modules/dispute/BondedDisputeModule.sol
@@ -38,8 +38,7 @@ contract BondedDisputeModule is Module, IBondedDisputeModule {
       _requestId: _dispute.requestId,
       _responseId: _dispute.responseId,
       _disputeId: _getId(_dispute),
-      _dispute: _dispute,
-      _blockNumber: block.number
+      _dispute: _dispute
     });
   }
 

--- a/solidity/contracts/modules/dispute/CircuitResolverModule.sol
+++ b/solidity/contracts/modules/dispute/CircuitResolverModule.sol
@@ -85,8 +85,7 @@ contract CircuitResolverModule is Module, ICircuitResolverModule {
       _requestId: _response.requestId,
       _responseId: _dispute.responseId,
       _disputeId: _getId(_dispute),
-      _dispute: _dispute,
-      _blockNumber: block.number
+      _dispute: _dispute
     });
 
     ORACLE.updateDisputeStatus(_request, _response, _dispute, _status);

--- a/solidity/contracts/modules/dispute/RootVerificationModule.sol
+++ b/solidity/contracts/modules/dispute/RootVerificationModule.sol
@@ -83,8 +83,7 @@ contract RootVerificationModule is Module, IRootVerificationModule {
       _requestId: _response.requestId,
       _responseId: _dispute.responseId,
       _disputeId: _getId(_dispute),
-      _dispute: _dispute,
-      _blockNumber: block.number
+      _dispute: _dispute
     });
 
     ORACLE.updateDisputeStatus(_request, _response, _dispute, _status);

--- a/solidity/contracts/modules/response/BondedResponseModule.sol
+++ b/solidity/contracts/modules/response/BondedResponseModule.sol
@@ -75,14 +75,14 @@ contract BondedResponseModule is Module, IBondedResponseModule {
 
     bool _isModule = ORACLE.allowedModule(_response.requestId, _finalizer);
 
-    if (!_isModule && block.number < _params.deadline) {
+    if (!_isModule && block.timestamp < _params.deadline) {
       revert BondedResponseModule_TooEarlyToFinalize();
     }
 
     uint256 _responseCreatedAt = ORACLE.responseCreatedAt(_getId(_response));
 
     if (_responseCreatedAt != 0) {
-      if (!_isModule && block.number < _responseCreatedAt + _params.disputeWindow) {
+      if (!_isModule && block.timestamp < _responseCreatedAt + _params.disputeWindow) {
         revert BondedResponseModule_TooEarlyToFinalize();
       }
 

--- a/solidity/contracts/modules/response/BondedResponseModule.sol
+++ b/solidity/contracts/modules/response/BondedResponseModule.sol
@@ -62,7 +62,7 @@ contract BondedResponseModule is Module, IBondedResponseModule {
       });
     }
 
-    emit ResponseProposed(_response.requestId, _response, block.number);
+    emit ResponseProposed(_response.requestId, _response);
   }
 
   /// @inheritdoc IBondedResponseModule

--- a/solidity/interfaces/modules/response/IBondedResponseModule.sol
+++ b/solidity/interfaces/modules/response/IBondedResponseModule.sol
@@ -20,9 +20,8 @@ interface IBondedResponseModule is IResponseModule {
    *
    * @param _requestId The ID of the request that the response was proposed
    * @param _response The proposed response
-   * @param _blockNumber The number of the block in which the response was proposed
    */
-  event ResponseProposed(bytes32 indexed _requestId, IOracle.Response _response, uint256 indexed _blockNumber);
+  event ResponseProposed(bytes32 indexed _requestId, IOracle.Response _response);
 
   /**
    * @notice Emitted when an uncalled response is released

--- a/solidity/test/integration/BondEscalation.t.sol
+++ b/solidity/test/integration/BondEscalation.t.sol
@@ -152,7 +152,7 @@ contract Integration_BondEscalation is IntegrationBase {
     assertEq(_bondEscalationAccounting.balanceOf(disputer, usdc), 0, 'Mismatch: Disputer balance');
 
     // Step 8: Finalize request and check balances again
-    vm.roll(_expectedDeadline + 1 days);
+    vm.warp(_expectedDeadline + 1 days);
     oracle.finalize(mockRequest, mockResponse);
 
     // Test: The requester has no balance because he has paid the proposer
@@ -248,7 +248,7 @@ contract Integration_BondEscalation is IntegrationBase {
     _responseId = oracle.proposeResponse(mockRequest, _thirdResponse);
 
     // Step 11: It goes undisputed for three days, therefore it's deemed correct and final
-    vm.roll(_expectedDeadline + 1);
+    vm.warp(_expectedDeadline + 1);
     oracle.finalize(mockRequest, _thirdResponse);
 
     // Test: The requester has paid out the reward
@@ -283,7 +283,7 @@ contract Integration_BondEscalation is IntegrationBase {
 
     // Step 12: Two days after the deadline, the resolution module says that Another proposer's answer was correct
     // So Another proposer gets paid Disputer's bond
-    vm.roll(_expectedDeadline + 2 days);
+    vm.warp(_expectedDeadline + 2 days);
     _mockArbitrator.setAnswer(IOracle.DisputeStatus.Lost);
     oracle.resolveDispute(mockRequest, _secondResponse, _secondDispute);
 

--- a/solidity/test/integration/Finalization.t.sol
+++ b/solidity/test/integration/Finalization.t.sol
@@ -70,7 +70,7 @@ contract Integration_Finalization is IntegrationBase {
    * @notice Finalizing a request with a ongoing dispute reverts.
    */
   function test_revertFinalizeInDisputeWindow(uint256 _block) public {
-    _block = bound(_block, block.number, _expectedDeadline - _baseDisputeWindow - 1);
+    _block = bound(_block, block.timestamp, _expectedDeadline - _baseDisputeWindow - 1);
 
     _createRequest();
     _proposeResponse();

--- a/solidity/test/integration/Finalization.t.sol
+++ b/solidity/test/integration/Finalization.t.sol
@@ -27,7 +27,7 @@ contract Integration_Finalization is IntegrationBase {
     _proposeResponse();
 
     // Traveling to the end of the dispute window
-    vm.roll(_expectedDeadline + 1 + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + 1 + _baseDisputeWindow);
 
     // Check: all external calls are made?
     vm.expectCall(address(_mockCallback), abi.encodeWithSelector(IProphetCallback.prophetCallback.selector, _calldata));
@@ -69,13 +69,13 @@ contract Integration_Finalization is IntegrationBase {
   /**
    * @notice Finalizing a request with a ongoing dispute reverts.
    */
-  function test_revertFinalizeInDisputeWindow(uint256 _block) public {
-    _block = bound(_block, block.timestamp, _expectedDeadline - _baseDisputeWindow - 1);
+  function test_revertFinalizeInDisputeWindow(uint256 _timestamp) public {
+    _timestamp = bound(_timestamp, block.timestamp, _expectedDeadline - _baseDisputeWindow - 1);
 
     _createRequest();
     _proposeResponse();
 
-    vm.roll(_block);
+    vm.warp(_timestamp);
 
     // Check: reverts if called during the dispute window?
     vm.expectRevert(IBondedResponseModule.BondedResponseModule_TooEarlyToFinalize.selector);
@@ -96,7 +96,7 @@ contract Integration_Finalization is IntegrationBase {
     _proposeResponse();
 
     // Traveling to the end of the dispute window
-    vm.roll(_expectedDeadline + 1 + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + 1 + _baseDisputeWindow);
 
     vm.expectCall(address(_mockCallback), abi.encodeWithSelector(IProphetCallback.prophetCallback.selector, _calldata));
     vm.prank(_finalizer);

--- a/solidity/test/integration/IntegrationBase.sol
+++ b/solidity/test/integration/IntegrationBase.sol
@@ -81,9 +81,10 @@ contract IntegrationBase is DSTestPlus, TestConstants, Helpers {
   uint256 internal _expectedReward = 30 ether;
   uint256 internal _expectedDeadline;
   uint256 internal _expectedCallbackValue = 42;
-  uint256 internal _baseDisputeWindow = 120; // blocks
+  uint256 internal _baseDisputeWindow = 120 * BLOCK_TIME;
   bytes32 internal _ipfsHash = bytes32('QmR4uiJH654k3Ta2uLLQ8r');
   uint256 internal _blocksDeadline = 600;
+  uint256 internal _timestampDeadline = _blocksDeadline * BLOCK_TIME;
 
   function setUp() public virtual {
     vm.createSelectFork(vm.rpcUrl('optimism'), FORK_BLOCK);
@@ -135,7 +136,7 @@ contract IntegrationBase is DSTestPlus, TestConstants, Helpers {
     vm.stopPrank();
 
     // Set the expected deadline
-    _expectedDeadline = block.timestamp + BLOCK_TIME * _blocksDeadline;
+    _expectedDeadline = block.timestamp + _timestampDeadline;
 
     // Configure the mock request
     mockRequest.requestModuleData = abi.encode(

--- a/solidity/test/integration/Payments.t.sol
+++ b/solidity/test/integration/Payments.t.sol
@@ -26,7 +26,7 @@ contract Integration_Payments is IntegrationBase {
     assertEq(_accountingExtension.bondedAmountOf(proposer, usdc, _requestId), _bondSize);
 
     // Warp to finalization time.
-    vm.roll(_expectedDeadline + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + _baseDisputeWindow);
 
     // Finalize request/response
     oracle.finalize(mockRequest, mockResponse);
@@ -66,7 +66,7 @@ contract Integration_Payments is IntegrationBase {
     assertEq(_accountingExtension.bondedAmountOf(proposer, weth, _requestId), _bondSize);
 
     // Warp to finalization time.
-    vm.roll(_expectedDeadline + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + _baseDisputeWindow);
     // Finalize request/response.
     oracle.finalize(mockRequest, mockResponse);
 

--- a/solidity/test/integration/RequestCreation.t.sol
+++ b/solidity/test/integration/RequestCreation.t.sol
@@ -34,7 +34,7 @@ contract Integration_RequestCreation is IntegrationBase {
     // Check: saved the correct nonce?
     assertEq(oracle.nonceToRequestId(mockRequest.nonce), _requestId);
 
-    // Check: saved the correct creation block?
+    // Check: saved the correct creation timestamp?
     assertEq(oracle.requestCreatedAt(_requestId), block.timestamp);
 
     // Check: saved the allowed modules?
@@ -60,7 +60,7 @@ contract Integration_RequestCreation is IntegrationBase {
     // Check: saved the correct nonce?
     assertEq(oracle.nonceToRequestId(mockRequest.nonce), _requestId);
 
-    // Check: saved the correct creation block?
+    // Check: saved the correct creation timestamp?
     assertEq(oracle.requestCreatedAt(_requestId), block.timestamp);
 
     // Check: saved the allowed modules?

--- a/solidity/test/integration/RequestCreation.t.sol
+++ b/solidity/test/integration/RequestCreation.t.sol
@@ -35,7 +35,7 @@ contract Integration_RequestCreation is IntegrationBase {
     assertEq(oracle.nonceToRequestId(mockRequest.nonce), _requestId);
 
     // Check: saved the correct creation block?
-    assertEq(oracle.requestCreatedAt(_requestId), block.number);
+    assertEq(oracle.requestCreatedAt(_requestId), block.timestamp);
 
     // Check: saved the allowed modules?
     assertTrue(oracle.allowedModule(_requestId, mockRequest.requestModule));
@@ -61,7 +61,7 @@ contract Integration_RequestCreation is IntegrationBase {
     assertEq(oracle.nonceToRequestId(mockRequest.nonce), _requestId);
 
     // Check: saved the correct creation block?
-    assertEq(oracle.requestCreatedAt(_requestId), block.number);
+    assertEq(oracle.requestCreatedAt(_requestId), block.timestamp);
 
     // Check: saved the allowed modules?
     assertTrue(oracle.allowedModule(_requestId, mockRequest.requestModule));

--- a/solidity/test/integration/ResponseDispute.t.sol
+++ b/solidity/test/integration/ResponseDispute.t.sol
@@ -83,7 +83,7 @@ contract Integration_ResponseDispute is IntegrationBase {
    * @notice Disputing a finalized response should revert
    */
   function test_disputeResponse_alreadyFinalized() public {
-    vm.roll(_expectedDeadline + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + _baseDisputeWindow);
     oracle.finalize(mockRequest, mockResponse);
 
     vm.expectRevert(abi.encodeWithSelector(IOracle.Oracle_AlreadyFinalized.selector, _getId(mockRequest)));

--- a/solidity/test/integration/ResponseDispute.t.sol
+++ b/solidity/test/integration/ResponseDispute.t.sol
@@ -39,7 +39,7 @@ contract Integration_ResponseDispute is IntegrationBase {
     assertEq(oracle.disputeOf(_getId(mockResponse)), _disputeId);
 
     // Check: creation time is correct?
-    assertEq(oracle.disputeCreatedAt(_disputeId), block.number);
+    assertEq(oracle.disputeCreatedAt(_disputeId), block.timestamp);
   }
 
   /**

--- a/solidity/test/integration/ResponseProposal.t.sol
+++ b/solidity/test/integration/ResponseProposal.t.sol
@@ -40,7 +40,7 @@ contract Integration_ResponseProposal is IntegrationBase {
     bytes32[] memory _getResponseIds = oracle.getResponseIds(_requestId);
     assertEq(_getResponseIds[0], _getId(mockResponse));
 
-    // Check: the creation block is correct?
+    // Check: the creation timestamp is correct?
     assertEq(oracle.responseCreatedAt(_getId(mockResponse)), block.timestamp);
   }
 

--- a/solidity/test/integration/ResponseProposal.t.sol
+++ b/solidity/test/integration/ResponseProposal.t.sol
@@ -41,7 +41,7 @@ contract Integration_ResponseProposal is IntegrationBase {
     assertEq(_getResponseIds[0], _getId(mockResponse));
 
     // Check: the creation block is correct?
-    assertEq(oracle.responseCreatedAt(_getId(mockResponse)), block.number);
+    assertEq(oracle.responseCreatedAt(_getId(mockResponse)), block.timestamp);
   }
 
   /**

--- a/solidity/test/integration/RootVerification.t.sol
+++ b/solidity/test/integration/RootVerification.t.sol
@@ -106,7 +106,7 @@ contract Integration_RootVerification is IntegrationBase {
     vm.prank(proposer);
     oracle.proposeResponse(mockRequest, mockResponse);
 
-    vm.roll(_expectedDeadline + _baseDisputeWindow);
+    vm.warp(_expectedDeadline + _baseDisputeWindow);
 
     oracle.finalize(mockRequest, mockResponse);
   }

--- a/solidity/test/unit/modules/dispute/BondEscalationModule.t.sol
+++ b/solidity/test/unit/modules/dispute/BondEscalationModule.t.sol
@@ -430,7 +430,7 @@ contract BondEscalationModule_Unit_DisputeResponse is BaseTest {
     mockDispute.responseId = _responseId;
 
     // Warp to a time after the disputeWindow is over.
-    vm.roll(block.number + _disputeWindow + 1);
+    vm.warp(block.timestamp + _disputeWindow + 1);
 
     // Mock and expect IOracle.responseCreatedAt to be called
     _mockAndExpect(address(oracle), abi.encodeCall(IOracle.responseCreatedAt, (_responseId)), abi.encode(1));
@@ -448,7 +448,7 @@ contract BondEscalationModule_Unit_DisputeResponse is BaseTest {
     uint256 _timestamp,
     IBondEscalationModule.RequestParameters memory _params
   ) public assumeFuzzable(address(_params.accountingExtension)) {
-    _timestamp = bound(_timestamp, 1, type(uint128).max);
+    _timestamp = bound(_timestamp, 1, 365 days);
     //  Set deadline to timestamp so we are still in the bond escalation period
     _params.bondEscalationDeadline = _timestamp - 1;
     _params.disputeWindow = _timestamp + 1;

--- a/solidity/test/unit/modules/dispute/BondEscalationModule.t.sol
+++ b/solidity/test/unit/modules/dispute/BondEscalationModule.t.sol
@@ -83,11 +83,7 @@ contract BaseTest is Test, Helpers {
     bytes32 indexed _requestId, bytes32 indexed _disputeId, IBondEscalationModule.BondEscalationStatus _status
   );
   event ResponseDisputed(
-    bytes32 indexed _requestId,
-    bytes32 indexed _responseId,
-    bytes32 indexed _disputeId,
-    IOracle.Dispute _dispute,
-    uint256 _blockNumber
+    bytes32 indexed _requestId, bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute
   );
   event DisputeStatusChanged(bytes32 indexed _disputeId, IOracle.Dispute _dispute, IOracle.DisputeStatus _status);
 
@@ -522,8 +518,7 @@ contract BondEscalationModule_Unit_DisputeResponse is BaseTest {
       _requestId: _requestId,
       _responseId: _responseId,
       _disputeId: _disputeId,
-      _dispute: mockDispute,
-      _blockNumber: block.number
+      _dispute: mockDispute
     });
 
     // Check: is the event emitted?
@@ -578,7 +573,7 @@ contract BondEscalationModule_Unit_DisputeResponse is BaseTest {
 
     // Check: is the event emitted?
     vm.expectEmit(true, true, true, true, address(bondEscalationModule));
-    emit ResponseDisputed(_requestId, _responseId, _disputeId, mockDispute, block.number);
+    emit ResponseDisputed(_requestId, _responseId, _disputeId, mockDispute);
 
     vm.prank(address(oracle));
     bondEscalationModule.disputeResponse(mockRequest, mockResponse, mockDispute);

--- a/solidity/test/unit/modules/dispute/BondedDisputeModule.t.sol
+++ b/solidity/test/unit/modules/dispute/BondedDisputeModule.t.sol
@@ -259,7 +259,7 @@ contract BondedDisputeModule_Unit_DisputeResponse is BaseTest {
 
     // Expect the event
     vm.expectEmit(true, true, true, true, address(bondedDisputeModule));
-    emit ResponseDisputed(_requestId, _getId(mockResponse), _getId(mockDispute), mockDispute, block.number);
+    emit ResponseDisputed(_requestId, _getId(mockResponse), _getId(mockDispute), mockDispute, block.timestamp);
 
     // Test: call disputeResponse
     vm.prank(address(oracle));

--- a/solidity/test/unit/modules/dispute/BondedDisputeModule.t.sol
+++ b/solidity/test/unit/modules/dispute/BondedDisputeModule.t.sol
@@ -28,11 +28,7 @@ contract BaseTest is Test, Helpers {
 
   event DisputeStatusChanged(bytes32 indexed _disputeId, IOracle.Dispute _dispute, IOracle.DisputeStatus _status);
   event ResponseDisputed(
-    bytes32 indexed _requestId,
-    bytes32 indexed _responseId,
-    bytes32 indexed _disputeId,
-    IOracle.Dispute _dispute,
-    uint256 _blockNumber
+    bytes32 indexed _requestId, bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute
   );
 
   /**
@@ -259,7 +255,7 @@ contract BondedDisputeModule_Unit_DisputeResponse is BaseTest {
 
     // Expect the event
     vm.expectEmit(true, true, true, true, address(bondedDisputeModule));
-    emit ResponseDisputed(_requestId, _getId(mockResponse), _getId(mockDispute), mockDispute, block.timestamp);
+    emit ResponseDisputed(_requestId, _getId(mockResponse), _getId(mockDispute), mockDispute);
 
     // Test: call disputeResponse
     vm.prank(address(oracle));

--- a/solidity/test/unit/modules/dispute/CircuitResolverModule.t.sol
+++ b/solidity/test/unit/modules/dispute/CircuitResolverModule.t.sol
@@ -43,11 +43,7 @@ contract BaseTest is Test, Helpers {
   // Events
   event DisputeStatusChanged(bytes32 indexed _disputeId, IOracle.Dispute _dispute, IOracle.DisputeStatus _status);
   event ResponseDisputed(
-    bytes32 indexed _requestId,
-    bytes32 indexed _responseId,
-    bytes32 indexed _disputeId,
-    IOracle.Dispute _dispute,
-    uint256 _blockNumber
+    bytes32 indexed _requestId, bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute
   );
 
   /**
@@ -217,8 +213,7 @@ contract CircuitResolverModule_Unit_DisputeResponse is BaseTest {
       _requestId: mockResponse.requestId,
       _responseId: mockDispute.responseId,
       _disputeId: _getId(mockDispute),
-      _dispute: mockDispute,
-      _blockNumber: block.number
+      _dispute: mockDispute
     });
 
     vm.prank(address(oracle));

--- a/solidity/test/unit/modules/dispute/RootVerificationModule.t.sol
+++ b/solidity/test/unit/modules/dispute/RootVerificationModule.t.sol
@@ -73,11 +73,7 @@ contract BaseTest is Test, Helpers {
 
   // Events
   event ResponseDisputed(
-    bytes32 indexed _requestId,
-    bytes32 indexed _responseId,
-    bytes32 indexed _disputeId,
-    IOracle.Dispute _dispute,
-    uint256 _blockNumber
+    bytes32 indexed _requestId, bytes32 indexed _responseId, bytes32 indexed _disputeId, IOracle.Dispute _dispute
   );
 
   /**
@@ -266,8 +262,7 @@ contract RootVerificationModule_Unit_DisputeResponse is BaseTest {
       _requestId: mockDispute.requestId,
       _responseId: mockDispute.responseId,
       _disputeId: _getId(mockDispute),
-      _dispute: mockDispute,
-      _blockNumber: block.number
+      _dispute: mockDispute
     });
 
     vm.prank(address(oracle));

--- a/solidity/test/unit/modules/response/BondedResponseModule.t.sol
+++ b/solidity/test/unit/modules/response/BondedResponseModule.t.sol
@@ -30,7 +30,7 @@ contract BaseTest is Test, Helpers {
   uint256 internal _baseDisputeWindow = 12 hours;
 
   // Events
-  event ResponseProposed(bytes32 indexed _requestId, IOracle.Response _response, uint256 indexed _blockNumber);
+  event ResponseProposed(bytes32 indexed _requestId, IOracle.Response _response);
   event UnutilizedResponseReleased(bytes32 indexed _requestId, bytes32 indexed _responseId);
 
   /**
@@ -170,7 +170,7 @@ contract BondedResponseModule_Unit_Propose is BaseTest {
 
     // Check: is the event emitted?
     vm.expectEmit(true, true, true, true, address(bondedResponseModule));
-    emit ResponseProposed({_requestId: _requestId, _response: mockResponse, _blockNumber: block.number});
+    emit ResponseProposed({_requestId: _requestId, _response: mockResponse});
 
     vm.prank(address(oracle));
     bondedResponseModule.propose(mockRequest, mockResponse, _proposer);

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,10 +193,10 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@defi-wonderland/prophet-core@0.0.0-0954a47f":
-  version "0.0.0-0954a47f"
-  resolved "https://registry.yarnpkg.com/@defi-wonderland/prophet-core/-/prophet-core-0.0.0-0954a47f.tgz#83124e103738a1d1d33b555ea774acbb90c0c153"
-  integrity sha512-MFJt7IQAkZys0wsJtFR4kt1x7zB1PMLr+jd40s14tLshlWm/7zrog8pfxUQ4EzYjVGkLKJm8jR8WcrEhCla39Q==
+"@defi-wonderland/prophet-core@0.0.0-4d28a0ec":
+  version "0.0.0-4d28a0ec"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/prophet-core/-/prophet-core-0.0.0-4d28a0ec.tgz#228896bb7b9b239c6c25b4deefa8b204d87d7118"
+  integrity sha512-BF+gSf+nZWNByr9V2/eUvdt7zHlScP0hF47L+grlllMHRadm8T7Eboo6jpIHOgMpLkfNAEVsOyg2vfvgABzACQ==
 
 "@defi-wonderland/solidity-utils@0.0.0-3e9c8e8b":
   version "0.0.0-3e9c8e8b"


### PR DESCRIPTION
# 🤖 Linear

Closes OPO-647

Tests pass using [this version](https://github.com/defi-wonderland/prophet-core/pull/46/) of prophet-core.